### PR TITLE
Optimize project list/card queryset

### DIFF
--- a/project/cbv/dashboard.py
+++ b/project/cbv/dashboard.py
@@ -94,8 +94,12 @@ class ProjectDetailView(HorillaDetailedView):
             ]
 
     def get_queryset(self) -> QuerySet[Any]:
-        queryset = super().get_queryset()
-        queryset = queryset.annotate(task_count=Count("task"))
+        queryset = (
+            super()
+            .get_queryset()
+            .prefetch_related("managers", "members", "task_set")
+            .annotate(task_count=Count("task"))
+        )
         return queryset
 
     @cached_property

--- a/project/cbv/projects.py
+++ b/project/cbv/projects.py
@@ -5,7 +5,7 @@ CBV of projects page
 from typing import Any
 
 from django.contrib import messages
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -158,13 +158,20 @@ class ProjectsList(HorillaListView):
     filter_class = ProjectFilter
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = (
+            super()
+            .get_queryset()
+            .prefetch_related("managers", "members", "task_set")
+            .annotate(task_count=Count("task"))
+        )
         if not self.request.user.has_perm("project.view_project"):
             employee = self.request.user.employee_get
             task_filter = queryset.filter(
                 Q(task__task_members=employee) | Q(task__task_managers=employee)
             )
-            project_filter = queryset.filter(Q(managers=employee) | Q(members=employee))
+            project_filter = queryset.filter(
+                Q(managers=employee) | Q(members=employee)
+            )
             queryset = task_filter | project_filter
         return queryset.distinct()
 
@@ -335,13 +342,20 @@ class ProjectCardView(HorillaCardView):
     filter_class = ProjectFilter
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = (
+            super()
+            .get_queryset()
+            .prefetch_related("managers", "members", "task_set")
+            .annotate(task_count=Count("task"))
+        )
         if not self.request.user.has_perm("project.view_project"):
             employee = self.request.user.employee_get
             task_filter = queryset.filter(
                 Q(task__task_members=employee) | Q(task__task_managers=employee)
             )
-            project_filter = queryset.filter(Q(managers=employee) | Q(members=employee))
+            project_filter = queryset.filter(
+                Q(managers=employee) | Q(members=employee)
+            )
             queryset = task_filter | project_filter
         return queryset.distinct()
 

--- a/project/models.py
+++ b/project/models.py
@@ -178,7 +178,9 @@ class Project(HorillaModel):
         return url
 
     def get_task_badge_html(self):
-        task_count = self.task_set.count()
+        task_count = getattr(self, "task_count", None)
+        if task_count is None:
+            task_count = self.task_set.count()
         title = self.title
         return format_html(
             '<div style="display: flex; align-items: center;">'

--- a/project/templates/cbv/projects/project_details.html
+++ b/project/templates/cbv/projects/project_details.html
@@ -55,7 +55,8 @@
           <span class="helpdesk__card-value" name="" id="">
             <div class="d-flex justify-content-between custom-scroll">
               <div class="avatars" id="avatarsContainer">
-                {% for manager in project.managers.all %}
+                {% with project.managers.all as managers %}
+                {% for manager in managers %}
                 <a
                   href="{% url 'employee-view-individual' manager.id %}"
                   class="avatars__item"
@@ -63,6 +64,7 @@
                   ><img class="avatar" src="{{manager.get_avatar}}" alt=""
                 /></a>
                 {% endfor %}
+                {% endwith %}
               </div>
             </div>
           </span>
@@ -72,7 +74,8 @@
           <span class="helpdesk__card-value" name="" id="">
             <div class="d-flex justify-content-between custom-scroll">
               <div class="avatars" id="avatarsContainer">
-                {% for menber in project.members.all %}
+                {% with project.members.all as members %}
+                {% for menber in members %}
                 <a
                   href="{% url 'employee-view-individual' menber.id %}"
                   class="avatars__item"
@@ -80,6 +83,7 @@
                   ><img class="avatar" src="{{menber.get_avatar}}" alt=""
                 /></a>
                 {% endfor %}
+                {% endwith %}
               </div>
             </div>
           </span>

--- a/project/templates/dashboard/project_details.html
+++ b/project/templates/dashboard/project_details.html
@@ -20,7 +20,11 @@
       </div>
       <div class="oh-timeoff-modal__stat" style="margin-left: 20px;">
           <span class="oh-timeoff-modal__stat-title">{% trans "Members" %}</span>
-          <span class="oh-timeoff-modal__stat-count">{% for member in project.members.all %}{{member}}, {% endfor %}</span>
+          <span class="oh-timeoff-modal__stat-count">
+            {% with project.members.all as members %}
+              {% for member in members %}{{member}}, {% endfor %}
+            {% endwith %}
+          </span>
       </div>
     </div>
     <div class="oh-timeoff-modal__stats-container mt-3 mb-3">

--- a/project/templates/project/new/project_list_view.html
+++ b/project/templates/project/new/project_list_view.html
@@ -98,8 +98,10 @@
 
             <div class="oh-sticky-table__td">{{project.manager}}</div>
             <div class="oh-sticky-table__td">
-              {% for employee in project.members.all %} {{employee}}<br />
+              {% with project.members.all as members %}
+              {% for employee in members %} {{employee}}<br />
               {% endfor %}
+              {% endwith %}
             </div>
             <div class="oh-sticky-table__td">{{project.get_status_display}}</div>
             <div class="oh-sticky-table__td">{{project.start_date}}</div>


### PR DESCRIPTION
## Summary
- prefetch managers, members, and tasks for project list and card views
- annotate task counts for projects
- use cached task count in `get_task_badge_html`
- ensure templates iterate over prefetched managers and members

## Testing
- `pytest -q` *(no tests found)*
- ❌ `pre-commit run --files project/cbv/projects.py project/models.py project/templates/cbv/projects/project_details.html project/templates/dashboard/project_details.html project/templates/project/new/project_list_view.html project/cbv/dashboard.py` *(failed: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688335888ff88327a4ad5042787a1cef