### PR TITLE
Fix missing delete script references

### DIFF
--- a/project/templates/cbv/projects/projects.html
+++ b/project/templates/cbv/projects/projects.html
@@ -140,7 +140,6 @@
     </div>
   </div>
 </div>
-<script src="{% static 'cbv/deleteFunc.js' %}"></script>
 <script src="{% static '/project/import.js' %}"></script>
 <script src="{% static '/project/project_action.js' %}"></script>
 

--- a/project/templates/cbv/tasks/task_template_view.html
+++ b/project/templates/cbv/tasks/task_template_view.html
@@ -87,7 +87,6 @@
 
 
 <script src="{% static '/task_all/task_all_action.js' %}"></script>
-<script src="{% static 'cbv/deleteFunc.js' %}"></script>
 
 <script>
 

--- a/project/templates/cbv/timesheet/timesheet.html
+++ b/project/templates/cbv/timesheet/timesheet.html
@@ -46,6 +46,5 @@
 <div class="oh-wrapper" id="listContainer">
     <div class="animated-background"></div>
 </div>
-<script src="{% static 'cbv/deleteFunc.js' %}"></script>
 <script src="{% static 'time_sheet/time_sheet_action.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove stale `deleteFunc.js` references to prevent 404s

## Testing
- `python -m django --version` *(fails: No module named django)*
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6883358cf5c08327a4170f778200bce0