### PR TITLE
Add loader hook and delay for timesheet search

### DIFF
--- a/project/templates/time_sheet/time_sheet_navbar.html
+++ b/project/templates/time_sheet/time_sheet_navbar.html
@@ -35,7 +35,8 @@
           name="search"
           placeholder="{% trans 'Search' %}"
           hx-get="{% url 'filter-time-sheet' %}"
-          hx-trigger="keyup changed delay:500ms, search"
+          hx-trigger="keyup changed delay:2000ms, search"
+          hx-on-htmx-before-request="htmxLoadIndicator(this);"
           hx-target="#TimeSheetList"
           hx-swap="innerHTML"
         />


### PR DESCRIPTION
## Summary
- delay timesheet search requests until 2 seconds of inactivity
- show HTMX loader for TimeSheetList when searching

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688845b3037c8327a18e7b39bc924a86