### PR TITLE
Adjust delays for search and notifications

### DIFF
--- a/notifications/static/notifications/notify.js
+++ b/notifications/static/notifications/notify.js
@@ -4,7 +4,7 @@ var notify_api_url;
 var notify_fetch_count;
 var notify_unread_url;
 var notify_mark_all_unread_url;
-var notify_refresh_period = 15000;
+var notify_refresh_period = 60000;
 var consecutive_misfires = 0;
 var registered_functions = [];
 

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -48,7 +48,7 @@ def has_notification(user):
 def register_notify_callbacks(
     badge_class="live_notify_badge",  # pylint: disable=too-many-arguments,missing-docstring
     menu_class="live_notify_list",
-    refresh_period=15,
+    refresh_period=60,
     callbacks="",
     api_name="list",
     fetch=5,

--- a/project/templates/time_sheet/time_sheet_navbar.html
+++ b/project/templates/time_sheet/time_sheet_navbar.html
@@ -35,7 +35,8 @@
           name="search"
           placeholder="{% trans 'Search' %}"
           hx-get="{% url 'filter-time-sheet' %}"
-          hx-trigger="keyup changed delay:500ms, search"
+          hx-trigger="keyup changed delay:2000ms, search"
+          hx-on-htmx-before-request="htmxLoadIndicator(this);"
           hx-target="#TimeSheetList"
           hx-swap="innerHTML"
         />


### PR DESCRIPTION
## Summary
- extend timesheet search delay to 2 seconds and invoke loader
- slow notification polling interval to 60 seconds

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688845b3037c8327a18e7b39bc924a86